### PR TITLE
Set ['view_manager']['display_exceptions'] to true in development mode.

### DIFF
--- a/config/autoload/global-development.php
+++ b/config/autoload/global-development.php
@@ -4,4 +4,8 @@
  * @copyright Copyright (c) 2013 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-return array();
+return array(
+    'view_manager' => array(
+        'display_exceptions' => true,
+    )
+);


### PR DESCRIPTION
Right now the value of that configuration variable is false even while development mode is enabled because its value is now determined by the fact that the module 'ZF\ApiProblem' is located after the module 'Application' in the 'modules' configuration variable at the 'config/application.config.php' file.

Useful to make Apigility end user support easier.
