### PR TITLE
Exist duplicate conf file while development mode is enabled.

### DIFF
--- a/module/Application/src/Application/Controller/DevelopmentModeController.php
+++ b/module/Application/src/Application/Controller/DevelopmentModeController.php
@@ -37,20 +37,13 @@ class DevelopmentModeController extends AbstractActionController
         $return = "Copying config/development.config.php.dist to config/development.config.php\n";
         copy('config/development.config.php.dist', 'config/development.config.php');
 
-        if (!file_exists('config/autoload/development.local.php')) {
-            $return .= "Copying config/autoload/global-development.php to config/autoload/development.local.php\n";
-            copy('config/autoload/global-development.php', 'config/autoload/development.local.php');
-        }
-
         $return .= "You are now in development mode.\n";
         return $return;
     }
 
     public function disableAction()
     {
-        if (!file_exists('config/development.config.php')
-            && !file_exists('config/autoload/development.local.php')
-        ) {
+        if (!file_exists('config/development.config.php')) {
             // nothing to do
             return "Development mode was already disabled.\n";
         }
@@ -60,11 +53,6 @@ class DevelopmentModeController extends AbstractActionController
         if (file_exists('config/development.config.php')) {
             $return .= "Removing config/development.config.php\n";
             unlink('config/development.config.php');
-        }
-
-        if (file_exists('config/autoload/development.local.php')) {
-            $return .= "Removing config/autoload/development.local.php\n";
-            unlink('config/autoload/development.local.php');
         }
 
         $return .= "Development mode is now disabled.\n";


### PR DESCRIPTION
When development mode is enabled the file 'config/development.config.php.dist' is copied to 'config/development.config.php' . This file [set value to 'config_glob_paths'](https://github.com/zfcampus/zf-apigility-skeleton/blob/master/config/development.config.php.dist#L16) that make the file 'config/autoload/global-development.php' useful for conf while in development mode.

At the same time, when development mode is enabled, the file 'config/autoload/global-development.php' is copied to 'config/autoload/development.local.php', coping  a file that already was referenced (taking into account) by the conf processing logic while in development mode, so the content of the file
'config/autoload/global-development.php' will be processed twice.

See comment [here](https://github.com/zfcampus/zf-apigility-skeleton/pull/28#issuecomment-30088148)
