### PR TITLE
Moved the ZF\Apigility\Welcome to development.config.php

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -11,7 +11,6 @@ return array(
         'ZF\DevelopmentMode',
         'ZF\Apigility',
         'ZF\Apigility\Provider',
-        'ZF\Apigility\Welcome',
         'ZF\Apigility\Documentation',
         'AssetManager',
         'ZF\ApiProblem',

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -9,6 +9,7 @@ return array(
     'modules' => array(
         'ZFTool',
         'ZF\Apigility\Admin',
+        'ZF\Apigility\Welcome',
         'ZF\Configuration',
     ),
     // development time configuration globbing


### PR DESCRIPTION
I moved the `ZF\Apigility\Welcome` module into `development.config.php.dist` because this module is not needed in production.
