### PR TITLE
Missing dependency - zf-console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "zfcampus/zf-apigility-admin": "~1.0-dev",
         "zfcampus/zf-configuration": "~1.0-dev",
         "zfcampus/zf-apigility-welcome": "~1.0-dev",
+        "zfcampus/zf-console": "~1.0-dev",
         "zfcampus/zf-deploy": "dev-master"
     }
 }


### PR DESCRIPTION
Missing zf-console dependency leads to:
- Installation request for zfcampus/zf-deploy dev-master -> satisfiable by zfcampus/zf-deploy[dev-master].
- zfcampus/zf-deploy dev-master requires zfcampus/zf-console ~1.0-dev -> no matching package found
