### PR TITLE
Prefix config glob path

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -35,6 +35,6 @@ return array(
         ),
         // Using __DIR__ to ensure cross-platform compatibility. Some platforms --
         // e.g., IBM i -- have problems with globs that are not qualified.
-        'config_glob_paths' => array(__DIR__ . '/autoload/{,*.}{global,local}.php')
+        'config_glob_paths' => array('config/autoload/{,*.}{global,local}.php')
     )
 );

--- a/public/index.php
+++ b/public/index.php
@@ -34,5 +34,18 @@ if (file_exists(APPLICATION_PATH . '/config/development.config.php')) {
     $appConfig = Zend\Stdlib\ArrayUtils::merge($appConfig, include APPLICATION_PATH . '/config/development.config.php');
 }
 
+// Some OS/Web Server combinations do not glob properly for paths unless they
+// are fully qualified (e.g., IBM i). The following prefixes the default glob
+// path with the value of the current working directory to ensure configuration
+// globbing will work cross-platform.
+if (isset($appConfig['module_listener_options']['config_glob_paths'])) {
+    foreach ($appConfig['module_listener_options']['config_glob_paths'] as $index => $path) {
+        if ($path !== 'config/autoload/{,*.}{global,local}.php') {
+            continue;
+        }
+        $appConfig['module_listener_options']['config_glob_paths'][$index] = getcwd() . '/' . $path;
+    }
+}
+
 // Run the application!
 Zend\Mvc\Application::init($appConfig)->run();


### PR DESCRIPTION
- If the default glob path is detected in the set of glob paths, prefix it with the value of `getcwd()` prior to passing it off to the application. This ensures the ConfigListener will be able to glob all paths correctly.
- Done in the bootstrap script (`public/index.php`) instead of `config/application.config.php` as Apigility writes to that file when creating or removing a module -- which means that the value of `getcwd()` would normally be expanded when written back. By making the change in the bootstrap, we can ensure the value remains untouched by Apigility.
