### PR TITLE
Bump ZF2 version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": ">=5.3.23",
-        "zendframework/zendframework": "~2.3",
+        "zendframework/zendframework": ">=2.3.2,<3.0.0",
         "zfcampus/zf-apigility": "~1.0",
         "zfcampus/zf-apigility-documentation": "~1.0",
         "zfcampus/zf-development-mode": "~2.0"


### PR DESCRIPTION
zendframework/ZendDeveloperTools#161 proposes to revert
zendframework/ZendDeveloperTools#158, which was introduced due to a
zendframework/ZendDeveloperTools#157, which was introduced due to a a ZDT
listener returning a boolean `true`, which would cause short-circuiting of
authorization listeners (and, consequently, cause any user to be considered
authorized!). Since ZF 2.3.2 fixes the root cause, by pinning to that, we can
be assured that when zendframework/ZendDeveloperTools#161 is merged, ZDT and
Apigility will continue to play well together.
