### PR TITLE
Changed the develop requirement for zf-apigility-admin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
     "require-dev": {
         "zendframework/zftool": "dev-master",
         "zendframework/zend-developer-tools": "dev-master",
-        "zfcampus/zf-apigility-admin": "~1.0",
+        "zfcampus/zf-apigility-admin": "dev-develop",
+        "zfcampus/zf-apigility-admin-ui": "dev-develop",
         "zfcampus/zf-deploy": "~1.0"
     }
 }


### PR DESCRIPTION
I changed the develop requirement for zf-apigility-admin. I also add the requirement for develop branch of zf-apigility-admin-ui because of a composer issue that does not load a dev version of a sub-dependency.