### PR TITLE
Return HTTP 500 by default

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -3,13 +3,26 @@
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
- 
- /*
-  * PHP by default returns HTTP 200 even when exceptions are thrown.
-  *
-  * Now by default return HTTP 500 so any API client can trust in the HTTP response code.
-  */
-http_response_code(500);
+
+if (ini_get('display_errors')) {
+    /*
+     * PHP by default returns HTTP 200 even when exceptions are thrown.
+     *
+     * Now by default return HTTP 500 so any API client can trust in the HTTP response code.
+     */
+    http_response_code(500);
+
+    function exception_error_handler($severity, $message, $file, $line)
+    {
+        if (!(error_reporting() & $severity)) {
+            // This error code is not included in error_reporting
+            return;
+        }
+        throw new ErrorException($message, 0, $severity, $file, $line);
+    }
+
+    set_error_handler("exception_error_handler");
+}
 
 /**
  * This makes our life easier when dealing with paths. Everything is relative

--- a/public/index.php
+++ b/public/index.php
@@ -3,6 +3,13 @@
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
+ 
+ /*
+  * PHP by default returns HTTP 200 even when exceptions are thrown.
+  *
+  * Now by default return HTTP 500 so any API client can trust in the HTTP response code.
+  */
+http_response_code(500);
 
 /**
  * This makes our life easier when dealing with paths. Everything is relative


### PR DESCRIPTION
As API provider is very critical trust in the HTTP Response code for to know if the transaction was successful.

Unfortunately any exception thrown will be returned with an HTTP 200 code when `display_errors` setting is enable