### PR TITLE
Move module list to separate config file.

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -5,25 +5,8 @@
  */
 
 return array(
-    // This should be an array of module namespaces used in the application.
-    'modules' => array(
-        'Application',
-        'ZF\DevelopmentMode',
-        'ZF\Apigility',
-        'ZF\Apigility\Provider',
-        'ZF\Apigility\Documentation',
-        'AssetManager',
-        'ZF\ApiProblem',
-        'ZF\Configuration',
-        'ZF\OAuth2',
-        'ZF\MvcAuth',
-        'ZF\Hal',
-        'ZF\ContentNegotiation',
-        'ZF\ContentValidation',
-        'ZF\Rest',
-        'ZF\Rpc',
-        'ZF\Versioning',
-    ),
+    // Retrieve the list of modules for this application.
+    'modules' => include __DIR__ . '/modules.config.php',
     // This should be an array of paths in which modules reside.
     // If a string key is provided, the listener will consider that a module
     // namespace, the value of that key the specific path to that module's

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
+ * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
+ */
+
+/**
+ * List of enabled modules for this application.
+ */
+return array(
+    'Application',
+    'ZF\DevelopmentMode',
+    'ZF\Apigility',
+    'ZF\Apigility\Provider',
+    'ZF\Apigility\Documentation',
+    'AssetManager',
+    'ZF\ApiProblem',
+    'ZF\Configuration',
+    'ZF\OAuth2',
+    'ZF\MvcAuth',
+    'ZF\Hal',
+    'ZF\ContentNegotiation',
+    'ZF\ContentValidation',
+    'ZF\Rest',
+    'ZF\Rpc',
+    'ZF\Versioning',
+);


### PR DESCRIPTION
This patch moves the module list to a separate configuration file. This is done to prevent evaluation of any PHP directives in the `config/application.config.php` file when reading and then writing the file on creation of a new API module and/or deletion of one. Since PHP directives are evaluated, the evaluated values are then written to the file, which may have unintended consequences, such as directory expansion!

This is a first step towards addressing zfcampus/zf-apigility-admin#289.