### PR TITLE
Use ZF\Apigility\Application

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": ">=5.3.23",
         "zendframework/zendframework": "~2.4",
-        "zfcampus/zf-apigility": "~1.0",
+        "zfcampus/zf-apigility": "~1.1",
         "zfcampus/zf-apigility-documentation": "^1.0.5",
         "zfcampus/zf-development-mode": "~2.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "322d2bbfcc4c2003bd878ad7eefd6d2f",
+    "hash": "098a8554436cbcafbb7e6bbcb68d3d92",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",

--- a/public/index.php
+++ b/public/index.php
@@ -1,4 +1,4 @@
-<?php
+<?php // @codingStandardsIgnoreFile
 /**
  * @license   http://opensource.org/licenses/BSD-3-Clause BSD-3-Clause
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
@@ -48,4 +48,4 @@ if (isset($appConfig['module_listener_options']['config_glob_paths'])) {
 }
 
 // Run the application!
-Zend\Mvc\Application::init($appConfig)->run();
+ZF\Apigility\Application::init($appConfig)->run();


### PR DESCRIPTION
Following up to zfcampus/zf-apigility#120, this patch updates the bootstrap to use `ZF\Apigility\Application` instead of `Zend\Mvc\Application` in order to ensure that exceptions thrown by Apigility's various route listeners are caught and return proper responses.

Fixes #83