### PR TITLE
Added setenvif to apache vhost in order to pass authorization headers

### DIFF
--- a/puphpet/config.yaml
+++ b/puphpet/config.yaml
@@ -171,6 +171,8 @@ apache:
             ssl_certs_dir: ''
             ssl_protocol: ''
             ssl_cipher: ''
+            setenvif:
+                - ^Authorization$ "(.+)" HTTP_AUTHORIZATION=$1
             directories:
                 avd_6rxty09c4zgy:
                     path: /var/www/public


### PR DESCRIPTION
Added setenvif to apache vhost in order to pass authorization headers for (oauth2) header authorization.