### PR TITLE
Set always_populate_raw_post_data to -1

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -31,7 +31,8 @@ WORKDIR /var/www
 
 VOLUME /var/www
 
-RUN cp /usr/src/php/php.ini-development /usr/local/etc/php/php.ini
+RUN cp /usr/src/php/php.ini-development /usr/local/etc/php/php.ini \
+ && sed -i 's/;always_populate_raw_post_data/always_populate_raw_post_data/g' /usr/local/etc/php/php.ini
 
 CMD composer install \
  && php public/index.php development enable \


### PR DESCRIPTION
I used the `Dockerfile-dev` container to run Apigility. It was not possible to download a package. The following error message occurred by clicking on the "Generate package" button:

```
PHP message: PHP Deprecated: Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version. To avoid this warning set 'always_populate_raw_post_data' to '-1' in php.ini and use the php://input stream instead. in Unknown on line 0
```

I updated the php.ini file accordingly.