### PR TITLE
Set UTF8 fo LC_ALL in Vagrant environment

### DIFF
--- a/puphpet/files/exec-always/set-local.sh
+++ b/puphpet/files/exec-always/set-local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo "Setting locale to fix encoding"
+sh -c "echo 'LC_ALL=en_US.UTF-8' >> /etc/environment"
+echo "done setting locale"


### PR DESCRIPTION
To reproduce:
```
vagrant up
vagrant reload --provision
```

This results in:
```
==> default: Error: /Stage[main]/Puphpet_php/Service[php5-fpm]: Could not evaluate: invalid byte sequence in US-ASCII
```

The problem is caused because there are i18n characters in the file due to an authors name.  To fix this on an existing install run sudo
```
sh -c "echo 'LC_ALL=en_US.UTF-8' >> /etc/environment"
```