### PR TITLE
.gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ vendor/
 config/development.config.php
 data/cache/*
 !data/cache/.gitkeep
+phpunit.xml
+ubuntu-xenial-16.04-cloudimg-console.log


### PR DESCRIPTION
Added entires into `.gitignore`:
- `phpunit.xml`
- `ubuntu-xenial-16.04-cloudimg-console.log` (as we noticed is created on running vagrant)