### PR TITLE
Fixes #142 : composer update --no-dev got PHP Fatal error: Class 'ZF\AssetManager\AssetInstaller' not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zfcampus/zf-apigility": "^1.3",
         "zfcampus/zf-apigility-documentation": "^1.2.2",
         "zfcampus/zf-asset-manager": "^1.1.1",
-        "zfcampus/zf-composer-autoloading": "^1.0"
+        "zfcampus/zf-composer-autoloading": "^1.0",
         "zfcampus/zf-development-mode": "^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
         "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev",
         "zfcampus/zf-apigility": "^1.3",
         "zfcampus/zf-apigility-documentation": "^1.2.2",
+        "zfcampus/zf-asset-manager": "^1.1.1",
+        "zfcampus/zf-composer-autoloading": "^1.0"
         "zfcampus/zf-development-mode": "^3.0"
     },
     "require-dev": {
         "zendframework/zend-developer-tools": "^1.1",
         "zfcampus/zf-apigility-admin": "^1.5.6",
-        "zfcampus/zf-asset-manager": "^1.1.1",
-        "zfcampus/zf-composer-autoloading": "^1.0",
         "zfcampus/zf-deploy": "^1.2"
     },
     "suggest": {
@@ -47,15 +47,15 @@
     "autoload": {
         "psr-4": {
             "Application\\": "module/Application/src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "ApplicationTest\\": "module/Application/test/"
         },
         "files": [
             "src/Apigility/constants.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "ApplicationTest\\": "module/Application/test/"
+        }
     },
     "scripts": {
         "cs-check": "phpcs",


### PR DESCRIPTION
- move some require-dev to require:
```
"zfcampus/zf-asset-manager": "^1.0",
 "zfcampus/zf-composer-autoloading": "^1.0",
```
- move Apiglity constant to require
```
"files": [
     "src/Apigility/constants.php"
 ]
```