### PR TITLE
Fixes #141 : Fixes PHP Fatal error: No base path provided when run php public.index.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,10 +40,10 @@
         "zfcampus/zf-deploy": "^1.2"
     },
     "suggest": {
+        "zendframework/zend-mvc-console": "^1.1 for its usage in zend-mvc v3",
         "zfcampus/zf-apigility-doctrine": "zfcampus/zf-apigility-doctrine ^2.1 to create Doctrine-Connected REST services",
         "zfcampus/zf-http-cache": "zfcampus/zf-http-cache ^1.3 to add HTTP caching to your API",
-        "zfr/zfr-cors": "zfr/zfr-cors ^1.2 to add CORS support to your API",
-        "zendframework/zend-mvc-console": "^1.1 for its usage in zend-mvc v3"
+        "zfr/zfr-cors": "zfr/zfr-cors ^1.2 to add CORS support to your API"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev",
+        "zendframework/zend-mvc-console": "^1.1",
         "zfcampus/zf-apigility": "^1.3",
         "zfcampus/zf-apigility-documentation": "^1.2.2",
         "zfcampus/zf-development-mode": "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-component-installer": "^1.0 || ^0.3 || ^1.0.0-dev@dev",
-        "zendframework/zend-mvc-console": "^1.1",
         "zfcampus/zf-apigility": "^1.3",
         "zfcampus/zf-apigility-documentation": "^1.2.2",
         "zfcampus/zf-development-mode": "^3.0"
@@ -43,7 +42,8 @@
     "suggest": {
         "zfcampus/zf-apigility-doctrine": "zfcampus/zf-apigility-doctrine ^2.1 to create Doctrine-Connected REST services",
         "zfcampus/zf-http-cache": "zfcampus/zf-http-cache ^1.3 to add HTTP caching to your API",
-        "zfr/zfr-cors": "zfr/zfr-cors ^1.2 to add CORS support to your API"
+        "zfr/zfr-cors": "zfr/zfr-cors ^1.2 to add CORS support to your API",
+        "zendframework/zend-mvc-console": "^1.1 for its usage in zend-mvc v3"
     },
     "autoload": {
         "psr-4": {

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -12,7 +12,7 @@ return [
     'Zend\Filter',
     'Zend\Hydrator',
     'Zend\InputFilter',
-    'Zend\Mvc\Console',
+    //'Zend\Mvc\Console', // activate it if you use zend-mvc v3
     'Zend\Paginator',
     'Zend\Router',
     'Zend\Validator',

--- a/config/modules.config.php
+++ b/config/modules.config.php
@@ -12,6 +12,7 @@ return [
     'Zend\Filter',
     'Zend\Hydrator',
     'Zend\InputFilter',
+    'Zend\Mvc\Console',
     'Zend\Paginator',
     'Zend\Router',
     'Zend\Validator',


### PR DESCRIPTION
fixed by add :
```
        "zendframework/zend-mvc-console": "^1.1",
```
to require section of composer.json