### PR TITLE
Vagrant box changed to `bento/ubuntu-16.04`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ config/development.config.php
 data/cache/*
 !data/cache/.gitkeep
 phpunit.xml
-ubuntu-xenial-16.04-cloudimg-console.log

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ $ vagrant ssh -c 'composer development-status'
 
 > #### Vagrant and VirtualBox
 >
-> The vagrant image is based on ubuntu/xenial64. If you are using VirtualBox as
+> The vagrant image is based on `bento/ubuntu-16.04`. If you are using VirtualBox as
 > a provider, you will need:
 >
 > - Vagrant 1.8.5 or later

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,13 +4,7 @@
 VAGRANTFILE_API_VERSION = '2'
 
 @script = <<SCRIPT
-# Fix for https://bugs.launchpad.net/ubuntu/+source/livecd-rootfs/+bug/1561250
-if ! grep -q "ubuntu-xenial" /etc/hosts; then
-    echo "127.0.0.1 ubuntu-xenial" >> /etc/hosts
-fi
-
 # Install dependencies
-add-apt-repository ppa:ondrej/php
 apt-get update
 apt-get install -y apache2 git curl php7.0 php7.0-bcmath php7.0-bz2 php7.0-cli php7.0-curl php7.0-intl php7.0-json php7.0-mbstring php7.0-opcache php7.0-soap php7.0-sqlite3 php7.0-xml php7.0-xsl php7.0-zip libapache2-mod-php7.0
 
@@ -40,8 +34,8 @@ else
 fi
 
 # Reset home directory of vagrant user
-if ! grep -q "cd /var/www" /home/ubuntu/.profile; then
-    echo "cd /var/www" >> /home/ubuntu/.profile
+if ! grep -q "cd /var/www" /home/vagrant/.profile; then
+    echo "cd /var/www" >> /home/vagrant/.profile
 fi
 
 echo "** [ZF] Run the following command to install dependencies, if you have not already:"
@@ -50,7 +44,7 @@ echo "** [ZF] Visit http://localhost:8080 in your browser for to view the applic
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = 'ubuntu/xenial64'
+  config.vm.box = 'bento/ubuntu-16.04'
   config.vm.network "forwarded_port", guest: 80, host: 8080
   config.vm.synced_folder '.', '/var/www'
   config.vm.provision 'shell', inline: @script


### PR DESCRIPTION
Updated to more stable Ubuntu vagrant box - `bento/ubuntu-16.04`.
Please see more for notes https://github.com/zendframework/ZendSkeletonApplication/pull/386