### PR TITLE
Incorporate code from migration tool

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,6 +13,21 @@ use ZF\Apigility\Application;
  */
 chdir(dirname(__DIR__));
 
+// Redirect legacy requests to enable/disable development mode to new tool
+if (php_sapi_name() === 'cli'
+    && $argc > 2
+    && 'development' == $argv[1]
+    && in_array($argv[2], ['disable', 'enable'])
+) {
+    // Windows needs to execute the batch scripts that Composer generates,
+    // and not the Unix shell version.
+    $script = defined('PHP_WINDOWS_VERSION_BUILD') && constant('PHP_WINDOWS_VERSION_BUILD')
+        ? '.\\vendor\\bin\\zf-development-mode.bat'
+        : './vendor/bin/zf-development-mode';
+    system(sprintf('%s %s', $script, $argv[2]), $return);
+    exit($return);
+}
+
 // Decline static file requests back to the PHP built-in webserver
 if (php_sapi_name() === 'cli-server' && is_file(__DIR__ . parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) {
     return false;


### PR DESCRIPTION
The Zend Studio integration always calls `public/index.php development enable` prior to invoking the admin; adding this code into the bootstrapping file ensures that the integration will continue to work with v1.4+ skeletons, until Studio updates to use the new tooling.