### PR TITLE
Fix Docker Container Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
  && apt-get install -y git zlib1g-dev \
  && docker-php-ext-install zip \
  && a2enmod rewrite \
- && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/sites-available/000-default.conf \
+ && sed -i 's!/var/www/html!/var/www/public!g' /etc/apache2/apache2.conf \
  && mv /var/www/html /var/www/public \
  && curl -sS https://getcomposer.org/installer \
   | php -- --install-dir=/usr/local/bin --filename=composer \


### PR DESCRIPTION
`apigility | AH00526: Syntax error on line 38 of /etc/apache2/apache2.conf:
apigility | DocumentRoot must be a directory
apigility exited with code 1`
