### PR TITLE
Add local development configs to gitignore

### DIFF
--- a/config/autoload/.gitignore
+++ b/config/autoload/.gitignore
@@ -1,2 +1,4 @@
 local.php
+local-development.php
 *.local.php
+*.local-development.php


### PR DESCRIPTION
Prevents local-development.php and *.local-development.php from beeing commited to version control