### PR TITLE
Update Vagrantfile to resolve permission issue on OS X with v2.2.2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ SCRIPT
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'bento/ubuntu-16.04'
   config.vm.network "forwarded_port", guest: 80, host: 8080
-  config.vm.synced_folder '.', '/var/www'
+  config.vm.synced_folder '.', '/var/www', owner: "www-data", group: "www-data"
   config.vm.provision 'shell', inline: @script
 
   config.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
Apache2 starts as www-data, but the Vagrantfile creates the /var/www folder as user "vagrant". Proposed change adjusts the ownership.